### PR TITLE
Remove debug print in `Tree::write_stl`

### DIFF
--- a/libfive/src/lib.rs
+++ b/libfive/src/lib.rs
@@ -767,8 +767,6 @@ impl Tree {
     ) -> Result<()> {
         let path = c_string_from_path(path);
 
-            println!("Foobar! {:?}", path);
-
         if unsafe {
             sys::libfive_tree_save_mesh(
                 self.0,


### PR DESCRIPTION
First, thank you for the libfive Rust bindings! 
They're working great for a project I am experimenting with :)

Spotted this print in `Tree::write_stl`, which was presumably added for debugging at some point.
This PR removes it to avoid any unwanted stdout.